### PR TITLE
copy-paste error

### DIFF
--- a/vms/libs/nx_vms_common/src/nx/analytics/metadata_log_parser.cpp
+++ b/vms/libs/nx_vms_common/src/nx/analytics/metadata_log_parser.cpp
@@ -86,7 +86,7 @@ bool MetadataLogParser::parseRectLine(
     if (!parseFloat(lineStream, line, "height", &height))
         return false;
     if (height < 0 || y + height > 1)
-        return warning(nx::format("\"height\" should be in range [0..1 - y], but is %2").args(width));
+        return warning(nx::format("\"height\" should be in range [0..1 - y], but is %2").args(height));
 
     *outRect = QRectF(x, y, width, height);
     return true;


### PR DESCRIPTION
Found this while doing static analysis. This part parses height, but then prints width if it finds an error.

Found using CodeSonar

<img width="1457" alt="Screenshot 2025-06-25 at 7 36 05 AM" src="https://github.com/user-attachments/assets/850ec51c-8e0a-4cca-ae29-f53b4998930f" />
