### PR TITLE
Miscellaneous inclusion fixes

### DIFF
--- a/libs/nx_utils/src/StdAfx.h
+++ b/libs/nx_utils/src/StdAfx.h
@@ -1,3 +1,3 @@
 // Copyright 2018-present Network Optix, Inc. Licensed under MPL 2.0: www.mozilla.org/MPL/2.0/
 
-#include <nx/utils/system_network_headers.h>
+#include "nx/utils/system_network_headers.h"

--- a/libs/nx_utils/src/nx/utils/std/algorithm.h
+++ b/libs/nx_utils/src/nx/utils/std/algorithm.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <QString>
 
 namespace nx {
 namespace utils {

--- a/libs/nx_utils/unit_tests/src/reflect/type_utils_ut.cpp
+++ b/libs/nx_utils/unit_tests/src/reflect/type_utils_ut.cpp
@@ -1,6 +1,8 @@
 // Copyright 2018-present Network Optix, Inc. Licensed under MPL 2.0: www.mozilla.org/MPL/2.0/
 
 #include <nx/reflect/type_utils.h>
+#include <QString>
+#include <QByteArray>
 
 namespace nx::reflect::test {
 


### PR DESCRIPTION
I am compiling NX Open with static analysis (CodeSonar) and without precompiled headers (for now). The fixes in this branch are needed to get the code to compile:
- Couple of missing includes that come out due to not using precompiled headers
- One inclusion that was using <> instead of "" and our parser is a bit more strict on that.

Figured I may was well report these, maybe it helps someone else.